### PR TITLE
Fixed length sig

### DIFF
--- a/extern/dilithium2/aarch64/api.h
+++ b/extern/dilithium2/aarch64/api.h
@@ -16,13 +16,13 @@ int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_keypair(
 );
 
 int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_signature(
-    uint8_t* sig, size_t* siglen,
+    uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t sk[PQCLEAN_DILITHIUM2_AARCH64_CRYPTO_SECRETKEYBYTES]
 );
 
 int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_verify(
-    const uint8_t* sig, size_t siglen,
+    const uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t pk[PQCLEAN_DILITHIUM2_AARCH64_CRYPTO_PUBLICKEYBYTES]
 );

--- a/extern/dilithium2/aarch64/sign.c
+++ b/extern/dilithium2/aarch64/sign.c
@@ -75,7 +75,6 @@ int DILITHIUM_NAMESPACE(crypto_sign_keypair)(
 *
 * Arguments:   - uint8_t* sig:   pointer to output signature (allocated array
 *                       of CRYPTO_BYTES bytes)
-*              - size_t* siglen: pointer to output length of signature
 *              - uint8_t* m:     pointer to message to be signed
 *              - size_t mlen:    length of message
 *              - const uint8_t sk[DILITHIUM_NAMESPACE(CRYPTO_SECRETKEYBYTES)]:
@@ -84,7 +83,7 @@ int DILITHIUM_NAMESPACE(crypto_sign_keypair)(
 * Returns 0 (success)
 **************************************************/
 int DILITHIUM_NAMESPACE(crypto_sign_signature)(
-    uint8_t* sig, size_t* siglen,
+    uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t sk[DILITHIUM_NAMESPACE(CRYPTO_SECRETKEYBYTES)]
 ) {
@@ -180,7 +179,6 @@ rej:
 
     /* Write signature */
     pack_sig(sig, sig, &z, &h);
-    *siglen = CRYPTO_BYTES;
     return 0;
 }
 
@@ -190,7 +188,6 @@ rej:
 * Description: Verifies signature.
 *
 * Arguments:   - uint8_t* m:        pointer to input signature
-*              - size_t siglen:     length of signature
 *              - const uint8_t* m:  pointer to message
 *              - size_t mlen:       length of message
 *              - const uint8_t pk[DILITHIUM_NAMESPACE(CRYPTO_PUBLICKEYBYTES)]:
@@ -199,7 +196,7 @@ rej:
 * Returns 0 if signature could be verified correctly and -1 otherwise
 **************************************************/
 int DILITHIUM_NAMESPACE(crypto_sign_verify)(
-    const uint8_t* sig, size_t siglen,
+    const uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t pk[DILITHIUM_NAMESPACE(CRYPTO_PUBLICKEYBYTES)]
 ) {
@@ -213,10 +210,6 @@ int DILITHIUM_NAMESPACE(crypto_sign_verify)(
     polyvecl mat[K], z;
     polyveck t1, w1, h;
     shake256incctx state;
-
-    if (siglen != CRYPTO_BYTES) {
-        return -1;
-    }
 
     unpack_pk(rho, &t1, pk);
     if (unpack_sig(c, &z, &h, sig)) {

--- a/extern/dilithium2/aarch64/sign.h
+++ b/extern/dilithium2/aarch64/sign.h
@@ -9,17 +9,17 @@
 int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_keypair(
     uint8_t pk[PQCLEAN_DILITHIUM2_AARCH64_CRYPTO_PUBLICKEYBYTES],
     uint8_t sk[PQCLEAN_DILITHIUM2_AARCH64_CRYPTO_SECRETKEYBYTES],
-    uint8_t random[128]
+    uint8_t random[2 * SEEDBYTES + CRHBYTES]
 );
 
 int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_signature(
-    uint8_t* sig, size_t* siglen,
+    uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t sk[PQCLEAN_DILITHIUM2_AARCH64_CRYPTO_SECRETKEYBYTES]
 );
 
 int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_verify(
-    const uint8_t* sig, size_t siglen,
+    const uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t pk[PQCLEAN_DILITHIUM2_AARCH64_CRYPTO_PUBLICKEYBYTES]
 );

--- a/extern/dilithium2/avx2/api.h
+++ b/extern/dilithium2/avx2/api.h
@@ -16,13 +16,13 @@ int PQCLEAN_DILITHIUM2_AVX2_crypto_sign_keypair(
 );
 
 int PQCLEAN_DILITHIUM2_AVX2_crypto_sign_signature(
-    uint8_t* sig, size_t* siglen,
+    uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t sk[PQCLEAN_DILITHIUM2_AVX2_CRYPTO_SECRETKEYBYTES]
 );
 
 int PQCLEAN_DILITHIUM2_AVX2_crypto_sign_verify(
-    const uint8_t* sig, size_t siglen,
+    const uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t pk[PQCLEAN_DILITHIUM2_AVX2_CRYPTO_PUBLICKEYBYTES]
 );

--- a/extern/dilithium2/avx2/sign.c
+++ b/extern/dilithium2/avx2/sign.c
@@ -115,7 +115,6 @@ int DILITHIUM_NAMESPACE(crypto_sign_keypair)(
 *
 * Arguments:   - uint8_t* sig:   pointer to output signature (allocated array
 *                       of CRYPTO_BYTES bytes)
-*              - size_t* siglen: pointer to output length of signature
 *              - uint8_t* m:     pointer to message to be signed
 *              - size_t mlen:    length of message
 *              - const uint8_t sk[DILITHIUM_NAMESPACE(CRYPTO_SECRETKEYBYTES)]:
@@ -124,7 +123,7 @@ int DILITHIUM_NAMESPACE(crypto_sign_keypair)(
 * Returns 0 (success)
 **************************************************/
 int DILITHIUM_NAMESPACE(crypto_sign_signature)(
-    uint8_t* sig, size_t* siglen,
+    uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t sk[DILITHIUM_NAMESPACE(CRYPTO_SECRETKEYBYTES)]
 ) {
@@ -243,7 +242,6 @@ rej:
         PQCLEAN_DILITHIUM2_AVX2_polyz_pack(sig + SEEDBYTES + i * POLYZ_PACKEDBYTES, &z.vec[i]);
     }
 
-    *siglen = PQCLEAN_DILITHIUM2_AVX2_CRYPTO_BYTES;
     return 0;
 }
 
@@ -253,7 +251,6 @@ rej:
 * Description: Verifies signature.
 *
 * Arguments:   - uint8_t* m:        pointer to input signature
-*              - size_t siglen:     length of signature
 *              - const uint8_t* m:  pointer to message
 *              - size_t mlen:       length of message
 *              - const uint8_t pk[DILITHIUM_NAMESPACE(CRYPTO_PUBLICKEYBYTES)]:
@@ -262,7 +259,7 @@ rej:
 * Returns 0 if signature could be verified correctly and -1 otherwise
 **************************************************/
 int DILITHIUM_NAMESPACE(crypto_sign_verify)(
-    const uint8_t* sig, size_t siglen,
+    const uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t pk[DILITHIUM_NAMESPACE(CRYPTO_PUBLICKEYBYTES)]
 ) {
@@ -276,10 +273,6 @@ int DILITHIUM_NAMESPACE(crypto_sign_verify)(
     polyvecl z;
     poly c, w1, h;
     shake256incctx state;
-
-    if (siglen != PQCLEAN_DILITHIUM2_AVX2_CRYPTO_BYTES) {
-        return -1;
-    }
 
     /* Compute CRH(H(rho, t1), msg) */
     shake256(mu, SEEDBYTES, pk, PQCLEAN_DILITHIUM2_AVX2_CRYPTO_PUBLICKEYBYTES);

--- a/extern/dilithium2/avx2/sign.h
+++ b/extern/dilithium2/avx2/sign.h
@@ -9,17 +9,17 @@
 int PQCLEAN_DILITHIUM2_AVX2_crypto_sign_keypair(
     uint8_t pk[PQCLEAN_DILITHIUM2_AVX2_CRYPTO_PUBLICKEYBYTES],
     uint8_t sk[PQCLEAN_DILITHIUM2_AVX2_CRYPTO_SECRETKEYBYTES],
-    uint8_t random[128]
+    uint8_t random[2 * SEEDBYTES + CRHBYTES]
 );
 
 int PQCLEAN_DILITHIUM2_AVX2_crypto_sign_signature(
-    uint8_t* sig, size_t* siglen,
+    uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t sk[PQCLEAN_DILITHIUM2_AVX2_CRYPTO_SECRETKEYBYTES]
 );
 
 int PQCLEAN_DILITHIUM2_AVX2_crypto_sign_verify(
-    const uint8_t* sig, size_t siglen,
+    const uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t pk[PQCLEAN_DILITHIUM2_AVX2_CRYPTO_PUBLICKEYBYTES]
 );

--- a/extern/dilithium2/clean/api.h
+++ b/extern/dilithium2/clean/api.h
@@ -16,13 +16,13 @@ int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_keypair(
 );
 
 int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_signature(
-    uint8_t* sig, size_t* siglen,
+    uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t sk[PQCLEAN_DILITHIUM2_CLEAN_CRYPTO_SECRETKEYBYTES]
 );
 
 int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_verify(
-    const uint8_t* sig, size_t siglen,
+    const uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t pk[PQCLEAN_DILITHIUM2_CLEAN_CRYPTO_PUBLICKEYBYTES]
 );

--- a/extern/dilithium2/clean/sign.c
+++ b/extern/dilithium2/clean/sign.c
@@ -75,7 +75,6 @@ int DILITHIUM_NAMESPACE(crypto_sign_keypair)(
 *
 * Arguments:   - uint8_t* sig:   pointer to output signature (allocated array
 *                       of CRYPTO_BYTES bytes)
-*              - size_t* siglen: pointer to output length of signature
 *              - uint8_t* m:     pointer to message to be signed
 *              - size_t mlen:    length of message
 *              - const uint8_t sk[DILITHIUM_NAMESPACE(CRYPTO_SECRETKEYBYTES)]:
@@ -84,7 +83,7 @@ int DILITHIUM_NAMESPACE(crypto_sign_keypair)(
 * Returns 0 (success)
 **************************************************/
 int DILITHIUM_NAMESPACE(crypto_sign_signature)(
-    uint8_t* sig, size_t* siglen,
+    uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t sk[DILITHIUM_NAMESPACE(CRYPTO_SECRETKEYBYTES)]
 ) {
@@ -180,7 +179,6 @@ rej:
 
     /* Write signature */
     PQCLEAN_DILITHIUM2_CLEAN_pack_sig(sig, sig, &z, &h);
-    *siglen = PQCLEAN_DILITHIUM2_CLEAN_CRYPTO_BYTES;
     return 0;
 }
 
@@ -190,7 +188,6 @@ rej:
 * Description: Verifies signature.
 *
 * Arguments:   - uint8_t* m:        pointer to input signature
-*              - size_t siglen:     length of signature
 *              - const uint8_t* m:  pointer to message
 *              - size_t mlen:       length of message
 *              - const uint8_t pk[DILITHIUM_NAMESPACE(CRYPTO_PUBLICKEYBYTES)]:
@@ -199,7 +196,7 @@ rej:
 * Returns 0 if signature could be verified correctly and -1 otherwise
 **************************************************/
 int DILITHIUM_NAMESPACE(crypto_sign_verify)(
-    const uint8_t* sig, size_t siglen,
+    const uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t pk[DILITHIUM_NAMESPACE(CRYPTO_PUBLICKEYBYTES)]
 ) {
@@ -213,10 +210,6 @@ int DILITHIUM_NAMESPACE(crypto_sign_verify)(
     polyvecl mat[K], z;
     polyveck t1, w1, h;
     shake256incctx state;
-
-    if (siglen != PQCLEAN_DILITHIUM2_CLEAN_CRYPTO_BYTES) {
-        return -1;
-    }
 
     PQCLEAN_DILITHIUM2_CLEAN_unpack_pk(rho, &t1, pk);
     if (PQCLEAN_DILITHIUM2_CLEAN_unpack_sig(c, &z, &h, sig)) {

--- a/extern/dilithium2/clean/sign.h
+++ b/extern/dilithium2/clean/sign.h
@@ -9,17 +9,17 @@
 int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_keypair(
     uint8_t pk[PQCLEAN_DILITHIUM2_CLEAN_CRYPTO_PUBLICKEYBYTES],
     uint8_t sk[PQCLEAN_DILITHIUM2_CLEAN_CRYPTO_SECRETKEYBYTES],
-    uint8_t random[128]
+    uint8_t random[2 * SEEDBYTES + CRHBYTES]
 );
 
 int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_signature(
-    uint8_t* sig, size_t* siglen,
+    uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t sk[PQCLEAN_DILITHIUM2_CLEAN_CRYPTO_SECRETKEYBYTES]
 );
 
 int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_verify(
-    const uint8_t* sig, size_t siglen,
+    const uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t pk[PQCLEAN_DILITHIUM2_CLEAN_CRYPTO_PUBLICKEYBYTES]
 );

--- a/extern/dilithium3/aarch64/api.h
+++ b/extern/dilithium3/aarch64/api.h
@@ -16,13 +16,13 @@ int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_keypair(
 );
 
 int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_signature(
-    uint8_t* sig, size_t* siglen,
+    uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t sk[PQCLEAN_DILITHIUM3_AARCH64_CRYPTO_SECRETKEYBYTES]
 );
 
 int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_verify(
-    const uint8_t* sig, size_t siglen,
+    const uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t pk[PQCLEAN_DILITHIUM3_AARCH64_CRYPTO_PUBLICKEYBYTES]
 );

--- a/extern/dilithium3/aarch64/sign.c
+++ b/extern/dilithium3/aarch64/sign.c
@@ -75,7 +75,6 @@ int DILITHIUM_NAMESPACE(crypto_sign_keypair)(
 *
 * Arguments:   - uint8_t* sig:   pointer to output signature (allocated array
 *                       of CRYPTO_BYTES bytes)
-*              - size_t* siglen: pointer to output length of signature
 *              - uint8_t* m:     pointer to message to be signed
 *              - size_t mlen:    length of message
 *              - const uint8_t sk[DILITHIUM_NAMESPACE(CRYPTO_SECRETKEYBYTES)]:
@@ -84,7 +83,7 @@ int DILITHIUM_NAMESPACE(crypto_sign_keypair)(
 * Returns 0 (success)
 **************************************************/
 int DILITHIUM_NAMESPACE(crypto_sign_signature)(
-    uint8_t* sig, size_t* siglen,
+    uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t sk[DILITHIUM_NAMESPACE(CRYPTO_SECRETKEYBYTES)]
 ) {
@@ -180,7 +179,6 @@ rej:
 
     /* Write signature */
     pack_sig(sig, sig, &z, &h);
-    *siglen = CRYPTO_BYTES;
     return 0;
 }
 
@@ -190,7 +188,6 @@ rej:
 * Description: Verifies signature.
 *
 * Arguments:   - uint8_t* m:        pointer to input signature
-*              - size_t siglen:     length of signature
 *              - const uint8_t* m:  pointer to message
 *              - size_t mlen:       length of message
 *              - const uint8_t pk[DILITHIUM_NAMESPACE(CRYPTO_PUBLICKEYBYTES)]:
@@ -199,7 +196,7 @@ rej:
 * Returns 0 if signature could be verified correctly and -1 otherwise
 **************************************************/
 int DILITHIUM_NAMESPACE(crypto_sign_verify)(
-    const uint8_t* sig, size_t siglen,
+    const uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t pk[DILITHIUM_NAMESPACE(CRYPTO_PUBLICKEYBYTES)]
 ) {
@@ -213,10 +210,6 @@ int DILITHIUM_NAMESPACE(crypto_sign_verify)(
     polyvecl mat[K], z;
     polyveck t1, w1, h;
     shake256incctx state;
-
-    if (siglen != CRYPTO_BYTES) {
-        return -1;
-    }
 
     unpack_pk(rho, &t1, pk);
     if (unpack_sig(c, &z, &h, sig)) {

--- a/extern/dilithium3/aarch64/sign.h
+++ b/extern/dilithium3/aarch64/sign.h
@@ -9,17 +9,17 @@
 int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_keypair(
     uint8_t pk[PQCLEAN_DILITHIUM3_AARCH64_CRYPTO_PUBLICKEYBYTES],
     uint8_t sk[PQCLEAN_DILITHIUM3_AARCH64_CRYPTO_SECRETKEYBYTES],
-    uint8_t random[128]
+    uint8_t random[2 * SEEDBYTES + CRHBYTES]
 );
 
 int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_signature(
-    uint8_t* sig, size_t* siglen,
+    uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t sk[PQCLEAN_DILITHIUM3_AARCH64_CRYPTO_SECRETKEYBYTES]
 );
 
 int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_verify(
-    const uint8_t* sig, size_t siglen,
+    const uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t pk[PQCLEAN_DILITHIUM3_AARCH64_CRYPTO_PUBLICKEYBYTES]
 );

--- a/extern/dilithium3/avx2/api.h
+++ b/extern/dilithium3/avx2/api.h
@@ -16,13 +16,13 @@ int PQCLEAN_DILITHIUM3_AVX2_crypto_sign_keypair(
 );
 
 int PQCLEAN_DILITHIUM3_AVX2_crypto_sign_signature(
-    uint8_t* sig, size_t* siglen,
+    uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t sk[PQCLEAN_DILITHIUM3_AVX2_CRYPTO_SECRETKEYBYTES]
 );
 
 int PQCLEAN_DILITHIUM3_AVX2_crypto_sign_verify(
-    const uint8_t* sig, size_t siglen,
+    const uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t pk[PQCLEAN_DILITHIUM3_AVX2_CRYPTO_PUBLICKEYBYTES]
 );

--- a/extern/dilithium3/avx2/sign.c
+++ b/extern/dilithium3/avx2/sign.c
@@ -124,7 +124,6 @@ int DILITHIUM_NAMESPACE(crypto_sign_keypair)(
 *
 * Arguments:   - uint8_t* sig:   pointer to output signature (allocated array
 *                       of CRYPTO_BYTES bytes)
-*              - size_t* siglen: pointer to output length of signature
 *              - uint8_t* m:     pointer to message to be signed
 *              - size_t mlen:    length of message
 *              - const uint8_t sk[DILITHIUM_NAMESPACE(CRYPTO_SECRETKEYBYTES)]:
@@ -133,7 +132,7 @@ int DILITHIUM_NAMESPACE(crypto_sign_keypair)(
 * Returns 0 (success)
 **************************************************/
 int DILITHIUM_NAMESPACE(crypto_sign_signature)(
-    uint8_t* sig, size_t* siglen,
+    uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t sk[DILITHIUM_NAMESPACE(CRYPTO_SECRETKEYBYTES)]
 ) {
@@ -253,7 +252,6 @@ rej:
         PQCLEAN_DILITHIUM3_AVX2_polyz_pack(sig + SEEDBYTES + i * POLYZ_PACKEDBYTES, &z.vec[i]);
     }
 
-    *siglen = PQCLEAN_DILITHIUM3_AVX2_CRYPTO_BYTES;
     return 0;
 }
 
@@ -263,7 +261,6 @@ rej:
 * Description: Verifies signature.
 *
 * Arguments:   - uint8_t* m:        pointer to input signature
-*              - size_t siglen:     length of signature
 *              - const uint8_t* m:  pointer to message
 *              - size_t mlen:       length of message
 *              - const uint8_t pk[DILITHIUM_NAMESPACE(CRYPTO_PUBLICKEYBYTES)]:
@@ -272,7 +269,7 @@ rej:
 * Returns 0 if signature could be verified correctly and -1 otherwise
 **************************************************/
 int DILITHIUM_NAMESPACE(crypto_sign_verify)(
-    const uint8_t* sig, size_t siglen,
+    const uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t pk[DILITHIUM_NAMESPACE(CRYPTO_PUBLICKEYBYTES)]
 ) {
@@ -286,10 +283,6 @@ int DILITHIUM_NAMESPACE(crypto_sign_verify)(
     polyvecl z;
     poly c, w1, h;
     shake256incctx state;
-
-    if (siglen != PQCLEAN_DILITHIUM3_AVX2_CRYPTO_BYTES) {
-        return -1;
-    }
 
     /* Compute CRH(H(rho, t1), msg) */
     shake256(mu, SEEDBYTES, pk, PQCLEAN_DILITHIUM3_AVX2_CRYPTO_PUBLICKEYBYTES);

--- a/extern/dilithium3/avx2/sign.h
+++ b/extern/dilithium3/avx2/sign.h
@@ -9,17 +9,17 @@
 int PQCLEAN_DILITHIUM3_AVX2_crypto_sign_keypair(
     uint8_t pk[PQCLEAN_DILITHIUM3_AVX2_CRYPTO_PUBLICKEYBYTES],
     uint8_t sk[PQCLEAN_DILITHIUM3_AVX2_CRYPTO_SECRETKEYBYTES],
-    uint8_t random[128]
+    uint8_t random[2 * SEEDBYTES + CRHBYTES]
 );
 
 int PQCLEAN_DILITHIUM3_AVX2_crypto_sign_signature(
-    uint8_t* sig, size_t* siglen,
+    uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t sk[PQCLEAN_DILITHIUM3_AVX2_CRYPTO_SECRETKEYBYTES]
 );
 
 int PQCLEAN_DILITHIUM3_AVX2_crypto_sign_verify(
-    const uint8_t* sig, size_t siglen,
+    const uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t pk[PQCLEAN_DILITHIUM3_AVX2_CRYPTO_PUBLICKEYBYTES]
 );

--- a/extern/dilithium3/clean/api.h
+++ b/extern/dilithium3/clean/api.h
@@ -16,13 +16,13 @@ int PQCLEAN_DILITHIUM3_CLEAN_crypto_sign_keypair(
 );
 
 int PQCLEAN_DILITHIUM3_CLEAN_crypto_sign_signature(
-    uint8_t* sig, size_t* siglen,
+    uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t sk[PQCLEAN_DILITHIUM3_CLEAN_CRYPTO_SECRETKEYBYTES]
 );
 
 int PQCLEAN_DILITHIUM3_CLEAN_crypto_sign_verify(
-    const uint8_t* sig, size_t siglen,
+    const uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t pk[PQCLEAN_DILITHIUM3_CLEAN_CRYPTO_PUBLICKEYBYTES]
 );

--- a/extern/dilithium3/clean/sign.c
+++ b/extern/dilithium3/clean/sign.c
@@ -75,7 +75,6 @@ int DILITHIUM_NAMESPACE(crypto_sign_keypair)(
 *
 * Arguments:   - uint8_t* sig:   pointer to output signature (allocated array
 *                       of CRYPTO_BYTES bytes)
-*              - size_t* siglen: pointer to output length of signature
 *              - uint8_t* m:     pointer to message to be signed
 *              - size_t mlen:    length of message
 *              - const uint8_t sk[DILITHIUM_NAMESPACE(CRYPTO_SECRETKEYBYTES)]:
@@ -84,7 +83,7 @@ int DILITHIUM_NAMESPACE(crypto_sign_keypair)(
 * Returns 0 (success)
 **************************************************/
 int DILITHIUM_NAMESPACE(crypto_sign_signature)(
-    uint8_t* sig, size_t* siglen,
+    uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t sk[DILITHIUM_NAMESPACE(CRYPTO_SECRETKEYBYTES)]
 ) {
@@ -180,7 +179,6 @@ rej:
 
     /* Write signature */
     PQCLEAN_DILITHIUM3_CLEAN_pack_sig(sig, sig, &z, &h);
-    *siglen = PQCLEAN_DILITHIUM3_CLEAN_CRYPTO_BYTES;
     return 0;
 }
 
@@ -190,7 +188,6 @@ rej:
 * Description: Verifies signature.
 *
 * Arguments:   - uint8_t* m:        pointer to input signature
-*              - size_t siglen:     length of signature
 *              - const uint8_t* m:  pointer to message
 *              - size_t mlen:       length of message
 *              - const uint8_t pk[DILITHIUM_NAMESPACE(CRYPTO_PUBLICKEYBYTES)]:
@@ -199,7 +196,7 @@ rej:
 * Returns 0 if signature could be verified correctly and -1 otherwise
 **************************************************/
 int DILITHIUM_NAMESPACE(crypto_sign_verify)(
-    const uint8_t* sig, size_t siglen,
+    const uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t pk[DILITHIUM_NAMESPACE(CRYPTO_PUBLICKEYBYTES)]
 ) {
@@ -213,10 +210,6 @@ int DILITHIUM_NAMESPACE(crypto_sign_verify)(
     polyvecl mat[K], z;
     polyveck t1, w1, h;
     shake256incctx state;
-
-    if (siglen != PQCLEAN_DILITHIUM3_CLEAN_CRYPTO_BYTES) {
-        return -1;
-    }
 
     PQCLEAN_DILITHIUM3_CLEAN_unpack_pk(rho, &t1, pk);
     if (PQCLEAN_DILITHIUM3_CLEAN_unpack_sig(c, &z, &h, sig)) {

--- a/extern/dilithium3/clean/sign.h
+++ b/extern/dilithium3/clean/sign.h
@@ -9,17 +9,17 @@
 int PQCLEAN_DILITHIUM3_CLEAN_crypto_sign_keypair(
     uint8_t pk[PQCLEAN_DILITHIUM3_CLEAN_CRYPTO_PUBLICKEYBYTES],
     uint8_t sk[PQCLEAN_DILITHIUM3_CLEAN_CRYPTO_SECRETKEYBYTES],
-    uint8_t random[128]
+    uint8_t random[2 * SEEDBYTES + CRHBYTES]
 );
 
 int PQCLEAN_DILITHIUM3_CLEAN_crypto_sign_signature(
-    uint8_t* sig, size_t* siglen,
+    uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t sk[PQCLEAN_DILITHIUM3_CLEAN_CRYPTO_SECRETKEYBYTES]
 );
 
 int PQCLEAN_DILITHIUM3_CLEAN_crypto_sign_verify(
-    const uint8_t* sig, size_t siglen,
+    const uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t pk[PQCLEAN_DILITHIUM3_CLEAN_CRYPTO_PUBLICKEYBYTES]
 );

--- a/extern/dilithium5/aarch64/api.h
+++ b/extern/dilithium5/aarch64/api.h
@@ -16,13 +16,13 @@ int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_keypair(
 );
 
 int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_signature(
-    uint8_t* sig, size_t* siglen,
+    uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t sk[PQCLEAN_DILITHIUM5_AARCH64_CRYPTO_SECRETKEYBYTES]
 );
 
 int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_verify(
-    const uint8_t* sig, size_t siglen,
+    const uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t pk[PQCLEAN_DILITHIUM5_AARCH64_CRYPTO_PUBLICKEYBYTES]
 );

--- a/extern/dilithium5/aarch64/sign.c
+++ b/extern/dilithium5/aarch64/sign.c
@@ -75,7 +75,6 @@ int DILITHIUM_NAMESPACE(crypto_sign_keypair)(
 *
 * Arguments:   - uint8_t* sig:   pointer to output signature (allocated array
 *                       of CRYPTO_BYTES bytes)
-*              - size_t* siglen: pointer to output length of signature
 *              - uint8_t* m:     pointer to message to be signed
 *              - size_t mlen:    length of message
 *              - const uint8_t sk[DILITHIUM_NAMESPACE(CRYPTO_SECRETKEYBYTES)]:
@@ -84,7 +83,7 @@ int DILITHIUM_NAMESPACE(crypto_sign_keypair)(
 * Returns 0 (success)
 **************************************************/
 int DILITHIUM_NAMESPACE(crypto_sign_signature)(
-    uint8_t* sig, size_t* siglen,
+    uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t sk[DILITHIUM_NAMESPACE(CRYPTO_SECRETKEYBYTES)]
 ) {
@@ -180,7 +179,6 @@ rej:
 
     /* Write signature */
     pack_sig(sig, sig, &z, &h);
-    *siglen = CRYPTO_BYTES;
     return 0;
 }
 
@@ -190,7 +188,6 @@ rej:
 * Description: Verifies signature.
 *
 * Arguments:   - uint8_t* m:        pointer to input signature
-*              - size_t siglen:     length of signature
 *              - const uint8_t* m:  pointer to message
 *              - size_t mlen:       length of message
 *              - const uint8_t pk[DILITHIUM_NAMESPACE(CRYPTO_PUBLICKEYBYTES)]:
@@ -199,7 +196,7 @@ rej:
 * Returns 0 if signature could be verified correctly and -1 otherwise
 **************************************************/
 int DILITHIUM_NAMESPACE(crypto_sign_verify)(
-    const uint8_t* sig, size_t siglen,
+    const uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t pk[DILITHIUM_NAMESPACE(CRYPTO_PUBLICKEYBYTES)]
 ) {
@@ -213,10 +210,6 @@ int DILITHIUM_NAMESPACE(crypto_sign_verify)(
     polyvecl mat[K], z;
     polyveck t1, w1, h;
     shake256incctx state;
-
-    if (siglen != CRYPTO_BYTES) {
-        return -1;
-    }
 
     unpack_pk(rho, &t1, pk);
     if (unpack_sig(c, &z, &h, sig)) {

--- a/extern/dilithium5/aarch64/sign.h
+++ b/extern/dilithium5/aarch64/sign.h
@@ -9,17 +9,17 @@
 int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_keypair(
     uint8_t pk[PQCLEAN_DILITHIUM5_AARCH64_CRYPTO_PUBLICKEYBYTES],
     uint8_t sk[PQCLEAN_DILITHIUM5_AARCH64_CRYPTO_SECRETKEYBYTES],
-    uint8_t random[128]
+    uint8_t random[2 * SEEDBYTES + CRHBYTES]
 );
 
 int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_signature(
-    uint8_t* sig, size_t* siglen,
+    uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t sk[PQCLEAN_DILITHIUM5_AARCH64_CRYPTO_SECRETKEYBYTES]
 );
 
 int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_verify(
-    const uint8_t* sig, size_t siglen,
+    const uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t pk[PQCLEAN_DILITHIUM5_AARCH64_CRYPTO_PUBLICKEYBYTES]
 );

--- a/extern/dilithium5/avx2/api.h
+++ b/extern/dilithium5/avx2/api.h
@@ -16,13 +16,13 @@ int PQCLEAN_DILITHIUM5_AVX2_crypto_sign_keypair(
 );
 
 int PQCLEAN_DILITHIUM5_AVX2_crypto_sign_signature(
-    uint8_t* sig, size_t* siglen,
+    uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t sk[PQCLEAN_DILITHIUM5_AVX2_CRYPTO_SECRETKEYBYTES]
 );
 
 int PQCLEAN_DILITHIUM5_AVX2_crypto_sign_verify(
-    const uint8_t* sig, size_t siglen,
+    const uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t pk[PQCLEAN_DILITHIUM5_AVX2_CRYPTO_PUBLICKEYBYTES]
 );

--- a/extern/dilithium5/avx2/sign.c
+++ b/extern/dilithium5/avx2/sign.c
@@ -133,7 +133,6 @@ int DILITHIUM_NAMESPACE(crypto_sign_keypair)(
 *
 * Arguments:   - uint8_t* sig:   pointer to output signature (allocated array
 *                       of CRYPTO_BYTES bytes)
-*              - size_t* siglen: pointer to output length of signature
 *              - uint8_t* m:     pointer to message to be signed
 *              - size_t mlen:    length of message
 *              - const uint8_t sk[DILITHIUM_NAMESPACE(CRYPTO_SECRETKEYBYTES)]:
@@ -142,7 +141,7 @@ int DILITHIUM_NAMESPACE(crypto_sign_keypair)(
 * Returns 0 (success)
 **************************************************/
 int DILITHIUM_NAMESPACE(crypto_sign_signature)(
-    uint8_t* sig, size_t* siglen,
+    uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t sk[DILITHIUM_NAMESPACE(CRYPTO_SECRETKEYBYTES)]
 ) {
@@ -263,7 +262,6 @@ rej:
         PQCLEAN_DILITHIUM5_AVX2_polyz_pack(sig + SEEDBYTES + i * POLYZ_PACKEDBYTES, &z.vec[i]);
     }
 
-    *siglen = PQCLEAN_DILITHIUM5_AVX2_CRYPTO_BYTES;
     return 0;
 }
 
@@ -273,7 +271,6 @@ rej:
 * Description: Verifies signature.
 *
 * Arguments:   - uint8_t* m:        pointer to input signature
-*              - size_t siglen:     length of signature
 *              - const uint8_t* m:  pointer to message
 *              - size_t mlen:       length of message
 *              - const uint8_t pk[DILITHIUM_NAMESPACE(CRYPTO_PUBLICKEYBYTES)]:
@@ -282,7 +279,7 @@ rej:
 * Returns 0 if signature could be verified correctly and -1 otherwise
 **************************************************/
 int DILITHIUM_NAMESPACE(crypto_sign_verify)(
-    const uint8_t* sig, size_t siglen,
+    const uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t pk[DILITHIUM_NAMESPACE(CRYPTO_PUBLICKEYBYTES)]
 ) {
@@ -296,10 +293,6 @@ int DILITHIUM_NAMESPACE(crypto_sign_verify)(
     polyvecl z;
     poly c, w1, h;
     shake256incctx state;
-
-    if (siglen != PQCLEAN_DILITHIUM5_AVX2_CRYPTO_BYTES) {
-        return -1;
-    }
 
     /* Compute CRH(H(rho, t1), msg) */
     shake256(mu, SEEDBYTES, pk, PQCLEAN_DILITHIUM5_AVX2_CRYPTO_PUBLICKEYBYTES);

--- a/extern/dilithium5/avx2/sign.h
+++ b/extern/dilithium5/avx2/sign.h
@@ -9,17 +9,17 @@
 int PQCLEAN_DILITHIUM5_AVX2_crypto_sign_keypair(
     uint8_t pk[PQCLEAN_DILITHIUM5_AVX2_CRYPTO_PUBLICKEYBYTES],
     uint8_t sk[PQCLEAN_DILITHIUM5_AVX2_CRYPTO_SECRETKEYBYTES],
-    uint8_t random[128]
+    uint8_t random[2 * SEEDBYTES + CRHBYTES]
 );
 
 int PQCLEAN_DILITHIUM5_AVX2_crypto_sign_signature(
-    uint8_t* sig, size_t* siglen,
+    uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t sk[PQCLEAN_DILITHIUM5_AVX2_CRYPTO_SECRETKEYBYTES]
 );
 
 int PQCLEAN_DILITHIUM5_AVX2_crypto_sign_verify(
-    const uint8_t* sig, size_t siglen,
+    const uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t pk[PQCLEAN_DILITHIUM5_AVX2_CRYPTO_PUBLICKEYBYTES]
 );

--- a/extern/dilithium5/clean/api.h
+++ b/extern/dilithium5/clean/api.h
@@ -16,13 +16,13 @@ int PQCLEAN_DILITHIUM5_CLEAN_crypto_sign_keypair(
 );
 
 int PQCLEAN_DILITHIUM5_CLEAN_crypto_sign_signature(
-    uint8_t* sig, size_t* siglen,
+    uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t sk[PQCLEAN_DILITHIUM5_CLEAN_CRYPTO_SECRETKEYBYTES]
 );
 
 int PQCLEAN_DILITHIUM5_CLEAN_crypto_sign_verify(
-    const uint8_t* sig, size_t siglen,
+    const uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t pk[PQCLEAN_DILITHIUM5_CLEAN_CRYPTO_PUBLICKEYBYTES]
 );

--- a/extern/dilithium5/clean/sign.c
+++ b/extern/dilithium5/clean/sign.c
@@ -75,7 +75,6 @@ int DILITHIUM_NAMESPACE(crypto_sign_keypair)(
 *
 * Arguments:   - uint8_t* sig:   pointer to output signature (allocated array
 *                       of CRYPTO_BYTES bytes)
-*              - size_t* siglen: pointer to output length of signature
 *              - uint8_t* m:     pointer to message to be signed
 *              - size_t mlen:    length of message
 *              - const uint8_t sk[DILITHIUM_NAMESPACE(CRYPTO_SECRETKEYBYTES)]:
@@ -84,7 +83,7 @@ int DILITHIUM_NAMESPACE(crypto_sign_keypair)(
 * Returns 0 (success)
 **************************************************/
 int DILITHIUM_NAMESPACE(crypto_sign_signature)(
-    uint8_t* sig, size_t* siglen,
+    uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t sk[DILITHIUM_NAMESPACE(CRYPTO_SECRETKEYBYTES)]
 ) {
@@ -180,7 +179,6 @@ rej:
 
     /* Write signature */
     PQCLEAN_DILITHIUM5_CLEAN_pack_sig(sig, sig, &z, &h);
-    *siglen = PQCLEAN_DILITHIUM5_CLEAN_CRYPTO_BYTES;
     return 0;
 }
 
@@ -190,7 +188,6 @@ rej:
 * Description: Verifies signature.
 *
 * Arguments:   - uint8_t* m:        pointer to input signature
-*              - size_t siglen:     length of signature
 *              - const uint8_t* m:  pointer to message
 *              - size_t mlen:       length of message
 *              - const uint8_t pk[DILITHIUM_NAMESPACE(CRYPTO_PUBLICKEYBYTES)]:
@@ -199,7 +196,7 @@ rej:
 * Returns 0 if signature could be verified correctly and -1 otherwise
 **************************************************/
 int DILITHIUM_NAMESPACE(crypto_sign_verify)(
-    const uint8_t* sig, size_t siglen,
+    const uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t pk[DILITHIUM_NAMESPACE(CRYPTO_PUBLICKEYBYTES)]
 ) {
@@ -213,10 +210,6 @@ int DILITHIUM_NAMESPACE(crypto_sign_verify)(
     polyvecl mat[K], z;
     polyveck t1, w1, h;
     shake256incctx state;
-
-    if (siglen != PQCLEAN_DILITHIUM5_CLEAN_CRYPTO_BYTES) {
-        return -1;
-    }
 
     PQCLEAN_DILITHIUM5_CLEAN_unpack_pk(rho, &t1, pk);
     if (PQCLEAN_DILITHIUM5_CLEAN_unpack_sig(c, &z, &h, sig)) {

--- a/extern/dilithium5/clean/sign.h
+++ b/extern/dilithium5/clean/sign.h
@@ -9,17 +9,17 @@
 int PQCLEAN_DILITHIUM5_CLEAN_crypto_sign_keypair(
     uint8_t pk[PQCLEAN_DILITHIUM5_CLEAN_CRYPTO_PUBLICKEYBYTES],
     uint8_t sk[PQCLEAN_DILITHIUM5_CLEAN_CRYPTO_SECRETKEYBYTES],
-    uint8_t random[128]
+    uint8_t random[2 * SEEDBYTES + CRHBYTES]
 );
 
 int PQCLEAN_DILITHIUM5_CLEAN_crypto_sign_signature(
-    uint8_t* sig, size_t* siglen,
+    uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t sk[PQCLEAN_DILITHIUM5_CLEAN_CRYPTO_SECRETKEYBYTES]
 );
 
 int PQCLEAN_DILITHIUM5_CLEAN_crypto_sign_verify(
-    const uint8_t* sig, size_t siglen,
+    const uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t pk[PQCLEAN_DILITHIUM5_CLEAN_CRYPTO_PUBLICKEYBYTES]
 );

--- a/scripts/ffi_modules.py
+++ b/scripts/ffi_modules.py
@@ -54,16 +54,14 @@ pub mod {impl} {{
         ) -> c_int;
 
         fn PQCLEAN_DILITHIUM{level}_{IMPL}_crypto_sign_signature(
-            sig: *mut u8,
-            siglen: *mut size_t,
+            sig: *mut [u8; SIGNATUREBYTES],
             m: *const u8,
             mlen: size_t,
             sk: *const [u8; SECRETKEYBYTES],
         ) -> c_int;
 
         fn PQCLEAN_DILITHIUM{level}_{IMPL}_crypto_sign_verify(
-            sig: *const u8,
-            siglen: size_t,
+            sig: *const [u8; SIGNATUREBYTES],
             m: *const u8,
             mlen: size_t,
             pk: *const [u8; PUBLICKEYBYTES],
@@ -82,14 +80,12 @@ pub mod {impl} {{
 
     pub unsafe fn crypto_sign_signature(
         sig: &mut [u8; SIGNATUREBYTES],
-        siglen: &mut usize,
         message: &[u8],
         sk: &[u8; SECRETKEYBYTES],
     ) -> c_int {{
         unsafe {{
             PQCLEAN_DILITHIUM{level}_{IMPL}_crypto_sign_signature(
-                sig as *mut u8,
-                siglen as *mut usize,
+                sig as *mut _,
                 message.as_ptr(),
                 message.len(),
                 sk as *const _,
@@ -98,14 +94,13 @@ pub mod {impl} {{
     }}
 
     pub unsafe fn crypto_sign_verify(
-        sig: &[u8],
+        sig: &[u8; SIGNATUREBYTES],
         message: &[u8],
         pk: &[u8; PUBLICKEYBYTES],
     ) -> c_int {{
         unsafe {{
             PQCLEAN_DILITHIUM{level}_{IMPL}_crypto_sign_verify(
-                sig.as_ptr(),
-                sig.len(),
+                sig as *const _,
                 message.as_ptr(),
                 message.len(),
                 pk as *const _,
@@ -135,11 +130,9 @@ pub mod {impl} {{
             assert_eq!(res, 0);
 
             let mut sig = [0u8; SIGNATUREBYTES];
-            let mut len: usize = 0;
             let res = unsafe {{
                 crypto_sign_signature(
                     &mut sig,
-                    &mut len,
                     &msg[..],
                     &seckey,
                 )
@@ -148,7 +141,7 @@ pub mod {impl} {{
 
             let res = unsafe {{
                 crypto_sign_verify(
-                    &sig[..len],
+                    &sig,
                     &msg[..],
                     &pubkey,
                 )

--- a/scripts/generate_api_h.py
+++ b/scripts/generate_api_h.py
@@ -32,13 +32,13 @@ int PQCLEAN_DILITHIUM{level}_{IMPL}_crypto_sign_keypair(
 );
 
 int PQCLEAN_DILITHIUM{level}_{IMPL}_crypto_sign_signature(
-    uint8_t* sig, size_t* siglen,
+    uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t sk[PQCLEAN_DILITHIUM{level}_{IMPL}_CRYPTO_SECRETKEYBYTES]
 );
 
 int PQCLEAN_DILITHIUM{level}_{IMPL}_crypto_sign_verify(
-    const uint8_t* sig, size_t siglen,
+    const uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t pk[PQCLEAN_DILITHIUM{level}_{IMPL}_CRYPTO_PUBLICKEYBYTES]
 );

--- a/scripts/generate_sign_c.py
+++ b/scripts/generate_sign_c.py
@@ -41,7 +41,6 @@ int DILITHIUM_NAMESPACE(crypto_sign_keypair)(
 *
 * Arguments:   - uint8_t* sig:   pointer to output signature (allocated array
 *                       of CRYPTO_BYTES bytes)
-*              - size_t* siglen: pointer to output length of signature
 *              - uint8_t* m:     pointer to message to be signed
 *              - size_t mlen:    length of message
 *              - const uint8_t sk[DILITHIUM_NAMESPACE(CRYPTO_SECRETKEYBYTES)]:
@@ -50,7 +49,7 @@ int DILITHIUM_NAMESPACE(crypto_sign_keypair)(
 * Returns 0 (success)
 **************************************************/
 int DILITHIUM_NAMESPACE(crypto_sign_signature)(
-    uint8_t* sig, size_t* siglen,
+    uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t sk[DILITHIUM_NAMESPACE(CRYPTO_SECRETKEYBYTES)]
 ) {{"""
@@ -62,7 +61,6 @@ int DILITHIUM_NAMESPACE(crypto_sign_signature)(
 * Description: Verifies signature.
 *
 * Arguments:   - uint8_t* m:        pointer to input signature
-*              - size_t siglen:     length of signature
 *              - const uint8_t* m:  pointer to message
 *              - size_t mlen:       length of message
 *              - const uint8_t pk[DILITHIUM_NAMESPACE(CRYPTO_PUBLICKEYBYTES)]:
@@ -71,7 +69,7 @@ int DILITHIUM_NAMESPACE(crypto_sign_signature)(
 * Returns 0 if signature could be verified correctly and -1 otherwise
 **************************************************/
 int DILITHIUM_NAMESPACE(crypto_sign_verify)(
-    const uint8_t* sig, size_t siglen,
+    const uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t pk[DILITHIUM_NAMESPACE(CRYPTO_PUBLICKEYBYTES)]
 ) {{"""
@@ -220,7 +218,6 @@ rej:
 
     /* Write signature */
     PQCLEAN_DILITHIUM{level}_CLEAN_pack_sig(sig, sig, &z, &h);
-    *siglen = PQCLEAN_DILITHIUM{level}_CLEAN_CRYPTO_BYTES;
     return 0;
 }}
 
@@ -235,10 +232,6 @@ rej:
     polyvecl mat[K], z;
     polyveck t1, w1, h;
     shake256incctx state;
-
-    if (siglen != PQCLEAN_DILITHIUM{level}_CLEAN_CRYPTO_BYTES) {{
-        return -1;
-    }}
 
     PQCLEAN_DILITHIUM{level}_CLEAN_unpack_pk(rho, &t1, pk);
     if (PQCLEAN_DILITHIUM{level}_CLEAN_unpack_sig(c, &z, &h, sig)) {{
@@ -546,7 +539,6 @@ rej:
         PQCLEAN_DILITHIUM{level}_AVX2_polyz_pack(sig + SEEDBYTES + i * POLYZ_PACKEDBYTES, &z.vec[i]);
     }}
 
-    *siglen = PQCLEAN_DILITHIUM{level}_AVX2_CRYPTO_BYTES;
     return 0;
 }}
 
@@ -561,10 +553,6 @@ rej:
     polyvecl z;
     poly c, w1, h;
     shake256incctx state;
-
-    if (siglen != PQCLEAN_DILITHIUM{level}_AVX2_CRYPTO_BYTES) {{
-        return -1;
-    }}
 
     /* Compute CRH(H(rho, t1), msg) */
     shake256(mu, SEEDBYTES, pk, PQCLEAN_DILITHIUM{level}_AVX2_CRYPTO_PUBLICKEYBYTES);
@@ -789,7 +777,6 @@ rej:
 
     /* Write signature */
     pack_sig(sig, sig, &z, &h);
-    *siglen = CRYPTO_BYTES;
     return 0;
 }}
 
@@ -804,10 +791,6 @@ rej:
     polyvecl mat[K], z;
     polyveck t1, w1, h;
     shake256incctx state;
-
-    if (siglen != CRYPTO_BYTES) {{
-        return -1;
-    }}
 
     unpack_pk(rho, &t1, pk);
     if (unpack_sig(c, &z, &h, sig)) {{

--- a/scripts/generate_sign_h.py
+++ b/scripts/generate_sign_h.py
@@ -29,13 +29,13 @@ int PQCLEAN_DILITHIUM{level}_{IMPL}_crypto_sign_keypair(
 );
 
 int PQCLEAN_DILITHIUM{level}_{IMPL}_crypto_sign_signature(
-    uint8_t* sig, size_t* siglen,
+    uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t sk[PQCLEAN_DILITHIUM{level}_{IMPL}_CRYPTO_SECRETKEYBYTES]
 );
 
 int PQCLEAN_DILITHIUM{level}_{IMPL}_crypto_sign_verify(
-    const uint8_t* sig, size_t siglen,
+    const uint8_t* sig,
     const uint8_t* m, size_t mlen,
     const uint8_t pk[PQCLEAN_DILITHIUM{level}_{IMPL}_CRYPTO_PUBLICKEYBYTES]
 );

--- a/src/ffi/dilithium2.rs
+++ b/src/ffi/dilithium2.rs
@@ -20,16 +20,14 @@ pub mod clean {
         ) -> c_int;
 
         fn PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_signature(
-            sig: *mut u8,
-            siglen: *mut size_t,
+            sig: *mut [u8; SIGNATUREBYTES],
             m: *const u8,
             mlen: size_t,
             sk: *const [u8; SECRETKEYBYTES],
         ) -> c_int;
 
         fn PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_verify(
-            sig: *const u8,
-            siglen: size_t,
+            sig: *const [u8; SIGNATUREBYTES],
             m: *const u8,
             mlen: size_t,
             pk: *const [u8; PUBLICKEYBYTES],
@@ -52,14 +50,12 @@ pub mod clean {
 
     pub unsafe fn crypto_sign_signature(
         sig: &mut [u8; SIGNATUREBYTES],
-        siglen: &mut usize,
         message: &[u8],
         sk: &[u8; SECRETKEYBYTES],
     ) -> c_int {
         unsafe {
             PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_signature(
-                sig as *mut u8,
-                siglen as *mut usize,
+                sig as *mut _,
                 message.as_ptr(),
                 message.len(),
                 sk as *const _,
@@ -68,14 +64,13 @@ pub mod clean {
     }
 
     pub unsafe fn crypto_sign_verify(
-        sig: &[u8],
+        sig: &[u8; SIGNATUREBYTES],
         message: &[u8],
         pk: &[u8; PUBLICKEYBYTES],
     ) -> c_int {
         unsafe {
             PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_verify(
-                sig.as_ptr(),
-                sig.len(),
+                sig as *const _,
                 message.as_ptr(),
                 message.len(),
                 pk as *const _,
@@ -99,11 +94,10 @@ pub mod clean {
             assert_eq!(res, 0);
 
             let mut sig = [0u8; SIGNATUREBYTES];
-            let mut len: usize = 0;
-            let res = unsafe { crypto_sign_signature(&mut sig, &mut len, &msg[..], &seckey) };
+            let res = unsafe { crypto_sign_signature(&mut sig, &msg[..], &seckey) };
             assert_eq!(res, 0);
 
-            let res = unsafe { crypto_sign_verify(&sig[..len], &msg[..], &pubkey) };
+            let res = unsafe { crypto_sign_verify(&sig, &msg[..], &pubkey) };
             assert_eq!(res, 0, "Invalid signature crated!");
         }
     }
@@ -126,16 +120,14 @@ pub mod avx2 {
         ) -> c_int;
 
         fn PQCLEAN_DILITHIUM2_AVX2_crypto_sign_signature(
-            sig: *mut u8,
-            siglen: *mut size_t,
+            sig: *mut [u8; SIGNATUREBYTES],
             m: *const u8,
             mlen: size_t,
             sk: *const [u8; SECRETKEYBYTES],
         ) -> c_int;
 
         fn PQCLEAN_DILITHIUM2_AVX2_crypto_sign_verify(
-            sig: *const u8,
-            siglen: size_t,
+            sig: *const [u8; SIGNATUREBYTES],
             m: *const u8,
             mlen: size_t,
             pk: *const [u8; PUBLICKEYBYTES],
@@ -158,14 +150,12 @@ pub mod avx2 {
 
     pub unsafe fn crypto_sign_signature(
         sig: &mut [u8; SIGNATUREBYTES],
-        siglen: &mut usize,
         message: &[u8],
         sk: &[u8; SECRETKEYBYTES],
     ) -> c_int {
         unsafe {
             PQCLEAN_DILITHIUM2_AVX2_crypto_sign_signature(
-                sig as *mut u8,
-                siglen as *mut usize,
+                sig as *mut _,
                 message.as_ptr(),
                 message.len(),
                 sk as *const _,
@@ -174,14 +164,13 @@ pub mod avx2 {
     }
 
     pub unsafe fn crypto_sign_verify(
-        sig: &[u8],
+        sig: &[u8; SIGNATUREBYTES],
         message: &[u8],
         pk: &[u8; PUBLICKEYBYTES],
     ) -> c_int {
         unsafe {
             PQCLEAN_DILITHIUM2_AVX2_crypto_sign_verify(
-                sig.as_ptr(),
-                sig.len(),
+                sig as *const _,
                 message.as_ptr(),
                 message.len(),
                 pk as *const _,
@@ -205,11 +194,10 @@ pub mod avx2 {
             assert_eq!(res, 0);
 
             let mut sig = [0u8; SIGNATUREBYTES];
-            let mut len: usize = 0;
-            let res = unsafe { crypto_sign_signature(&mut sig, &mut len, &msg[..], &seckey) };
+            let res = unsafe { crypto_sign_signature(&mut sig, &msg[..], &seckey) };
             assert_eq!(res, 0);
 
-            let res = unsafe { crypto_sign_verify(&sig[..len], &msg[..], &pubkey) };
+            let res = unsafe { crypto_sign_verify(&sig, &msg[..], &pubkey) };
             assert_eq!(res, 0, "Invalid signature crated!");
         }
     }
@@ -232,16 +220,14 @@ pub mod aarch64 {
         ) -> c_int;
 
         fn PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_signature(
-            sig: *mut u8,
-            siglen: *mut size_t,
+            sig: *mut [u8; SIGNATUREBYTES],
             m: *const u8,
             mlen: size_t,
             sk: *const [u8; SECRETKEYBYTES],
         ) -> c_int;
 
         fn PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_verify(
-            sig: *const u8,
-            siglen: size_t,
+            sig: *const [u8; SIGNATUREBYTES],
             m: *const u8,
             mlen: size_t,
             pk: *const [u8; PUBLICKEYBYTES],
@@ -264,14 +250,12 @@ pub mod aarch64 {
 
     pub unsafe fn crypto_sign_signature(
         sig: &mut [u8; SIGNATUREBYTES],
-        siglen: &mut usize,
         message: &[u8],
         sk: &[u8; SECRETKEYBYTES],
     ) -> c_int {
         unsafe {
             PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_signature(
-                sig as *mut u8,
-                siglen as *mut usize,
+                sig as *mut _,
                 message.as_ptr(),
                 message.len(),
                 sk as *const _,
@@ -280,14 +264,13 @@ pub mod aarch64 {
     }
 
     pub unsafe fn crypto_sign_verify(
-        sig: &[u8],
+        sig: &[u8; SIGNATUREBYTES],
         message: &[u8],
         pk: &[u8; PUBLICKEYBYTES],
     ) -> c_int {
         unsafe {
             PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_verify(
-                sig.as_ptr(),
-                sig.len(),
+                sig as *const _,
                 message.as_ptr(),
                 message.len(),
                 pk as *const _,
@@ -311,11 +294,10 @@ pub mod aarch64 {
             assert_eq!(res, 0);
 
             let mut sig = [0u8; SIGNATUREBYTES];
-            let mut len: usize = 0;
-            let res = unsafe { crypto_sign_signature(&mut sig, &mut len, &msg[..], &seckey) };
+            let res = unsafe { crypto_sign_signature(&mut sig, &msg[..], &seckey) };
             assert_eq!(res, 0);
 
-            let res = unsafe { crypto_sign_verify(&sig[..len], &msg[..], &pubkey) };
+            let res = unsafe { crypto_sign_verify(&sig, &msg[..], &pubkey) };
             assert_eq!(res, 0, "Invalid signature crated!");
         }
     }

--- a/src/ffi/dilithium3.rs
+++ b/src/ffi/dilithium3.rs
@@ -20,16 +20,14 @@ pub mod clean {
         ) -> c_int;
 
         fn PQCLEAN_DILITHIUM3_CLEAN_crypto_sign_signature(
-            sig: *mut u8,
-            siglen: *mut size_t,
+            sig: *mut [u8; SIGNATUREBYTES],
             m: *const u8,
             mlen: size_t,
             sk: *const [u8; SECRETKEYBYTES],
         ) -> c_int;
 
         fn PQCLEAN_DILITHIUM3_CLEAN_crypto_sign_verify(
-            sig: *const u8,
-            siglen: size_t,
+            sig: *const [u8; SIGNATUREBYTES],
             m: *const u8,
             mlen: size_t,
             pk: *const [u8; PUBLICKEYBYTES],
@@ -52,14 +50,12 @@ pub mod clean {
 
     pub unsafe fn crypto_sign_signature(
         sig: &mut [u8; SIGNATUREBYTES],
-        siglen: &mut usize,
         message: &[u8],
         sk: &[u8; SECRETKEYBYTES],
     ) -> c_int {
         unsafe {
             PQCLEAN_DILITHIUM3_CLEAN_crypto_sign_signature(
-                sig as *mut u8,
-                siglen as *mut usize,
+                sig as *mut _,
                 message.as_ptr(),
                 message.len(),
                 sk as *const _,
@@ -68,14 +64,13 @@ pub mod clean {
     }
 
     pub unsafe fn crypto_sign_verify(
-        sig: &[u8],
+        sig: &[u8; SIGNATUREBYTES],
         message: &[u8],
         pk: &[u8; PUBLICKEYBYTES],
     ) -> c_int {
         unsafe {
             PQCLEAN_DILITHIUM3_CLEAN_crypto_sign_verify(
-                sig.as_ptr(),
-                sig.len(),
+                sig as *const _,
                 message.as_ptr(),
                 message.len(),
                 pk as *const _,
@@ -99,11 +94,10 @@ pub mod clean {
             assert_eq!(res, 0);
 
             let mut sig = [0u8; SIGNATUREBYTES];
-            let mut len: usize = 0;
-            let res = unsafe { crypto_sign_signature(&mut sig, &mut len, &msg[..], &seckey) };
+            let res = unsafe { crypto_sign_signature(&mut sig, &msg[..], &seckey) };
             assert_eq!(res, 0);
 
-            let res = unsafe { crypto_sign_verify(&sig[..len], &msg[..], &pubkey) };
+            let res = unsafe { crypto_sign_verify(&sig, &msg[..], &pubkey) };
             assert_eq!(res, 0, "Invalid signature crated!");
         }
     }
@@ -126,16 +120,14 @@ pub mod avx2 {
         ) -> c_int;
 
         fn PQCLEAN_DILITHIUM3_AVX2_crypto_sign_signature(
-            sig: *mut u8,
-            siglen: *mut size_t,
+            sig: *mut [u8; SIGNATUREBYTES],
             m: *const u8,
             mlen: size_t,
             sk: *const [u8; SECRETKEYBYTES],
         ) -> c_int;
 
         fn PQCLEAN_DILITHIUM3_AVX2_crypto_sign_verify(
-            sig: *const u8,
-            siglen: size_t,
+            sig: *const [u8; SIGNATUREBYTES],
             m: *const u8,
             mlen: size_t,
             pk: *const [u8; PUBLICKEYBYTES],
@@ -158,14 +150,12 @@ pub mod avx2 {
 
     pub unsafe fn crypto_sign_signature(
         sig: &mut [u8; SIGNATUREBYTES],
-        siglen: &mut usize,
         message: &[u8],
         sk: &[u8; SECRETKEYBYTES],
     ) -> c_int {
         unsafe {
             PQCLEAN_DILITHIUM3_AVX2_crypto_sign_signature(
-                sig as *mut u8,
-                siglen as *mut usize,
+                sig as *mut _,
                 message.as_ptr(),
                 message.len(),
                 sk as *const _,
@@ -174,14 +164,13 @@ pub mod avx2 {
     }
 
     pub unsafe fn crypto_sign_verify(
-        sig: &[u8],
+        sig: &[u8; SIGNATUREBYTES],
         message: &[u8],
         pk: &[u8; PUBLICKEYBYTES],
     ) -> c_int {
         unsafe {
             PQCLEAN_DILITHIUM3_AVX2_crypto_sign_verify(
-                sig.as_ptr(),
-                sig.len(),
+                sig as *const _,
                 message.as_ptr(),
                 message.len(),
                 pk as *const _,
@@ -205,11 +194,10 @@ pub mod avx2 {
             assert_eq!(res, 0);
 
             let mut sig = [0u8; SIGNATUREBYTES];
-            let mut len: usize = 0;
-            let res = unsafe { crypto_sign_signature(&mut sig, &mut len, &msg[..], &seckey) };
+            let res = unsafe { crypto_sign_signature(&mut sig, &msg[..], &seckey) };
             assert_eq!(res, 0);
 
-            let res = unsafe { crypto_sign_verify(&sig[..len], &msg[..], &pubkey) };
+            let res = unsafe { crypto_sign_verify(&sig, &msg[..], &pubkey) };
             assert_eq!(res, 0, "Invalid signature crated!");
         }
     }
@@ -232,16 +220,14 @@ pub mod aarch64 {
         ) -> c_int;
 
         fn PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_signature(
-            sig: *mut u8,
-            siglen: *mut size_t,
+            sig: *mut [u8; SIGNATUREBYTES],
             m: *const u8,
             mlen: size_t,
             sk: *const [u8; SECRETKEYBYTES],
         ) -> c_int;
 
         fn PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_verify(
-            sig: *const u8,
-            siglen: size_t,
+            sig: *const [u8; SIGNATUREBYTES],
             m: *const u8,
             mlen: size_t,
             pk: *const [u8; PUBLICKEYBYTES],
@@ -264,14 +250,12 @@ pub mod aarch64 {
 
     pub unsafe fn crypto_sign_signature(
         sig: &mut [u8; SIGNATUREBYTES],
-        siglen: &mut usize,
         message: &[u8],
         sk: &[u8; SECRETKEYBYTES],
     ) -> c_int {
         unsafe {
             PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_signature(
-                sig as *mut u8,
-                siglen as *mut usize,
+                sig as *mut _,
                 message.as_ptr(),
                 message.len(),
                 sk as *const _,
@@ -280,14 +264,13 @@ pub mod aarch64 {
     }
 
     pub unsafe fn crypto_sign_verify(
-        sig: &[u8],
+        sig: &[u8; SIGNATUREBYTES],
         message: &[u8],
         pk: &[u8; PUBLICKEYBYTES],
     ) -> c_int {
         unsafe {
             PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_verify(
-                sig.as_ptr(),
-                sig.len(),
+                sig as *const _,
                 message.as_ptr(),
                 message.len(),
                 pk as *const _,
@@ -311,11 +294,10 @@ pub mod aarch64 {
             assert_eq!(res, 0);
 
             let mut sig = [0u8; SIGNATUREBYTES];
-            let mut len: usize = 0;
-            let res = unsafe { crypto_sign_signature(&mut sig, &mut len, &msg[..], &seckey) };
+            let res = unsafe { crypto_sign_signature(&mut sig, &msg[..], &seckey) };
             assert_eq!(res, 0);
 
-            let res = unsafe { crypto_sign_verify(&sig[..len], &msg[..], &pubkey) };
+            let res = unsafe { crypto_sign_verify(&sig, &msg[..], &pubkey) };
             assert_eq!(res, 0, "Invalid signature crated!");
         }
     }

--- a/src/ffi/dilithium5.rs
+++ b/src/ffi/dilithium5.rs
@@ -20,16 +20,14 @@ pub mod clean {
         ) -> c_int;
 
         fn PQCLEAN_DILITHIUM5_CLEAN_crypto_sign_signature(
-            sig: *mut u8,
-            siglen: *mut size_t,
+            sig: *mut [u8; SIGNATUREBYTES],
             m: *const u8,
             mlen: size_t,
             sk: *const [u8; SECRETKEYBYTES],
         ) -> c_int;
 
         fn PQCLEAN_DILITHIUM5_CLEAN_crypto_sign_verify(
-            sig: *const u8,
-            siglen: size_t,
+            sig: *const [u8; SIGNATUREBYTES],
             m: *const u8,
             mlen: size_t,
             pk: *const [u8; PUBLICKEYBYTES],
@@ -52,14 +50,12 @@ pub mod clean {
 
     pub unsafe fn crypto_sign_signature(
         sig: &mut [u8; SIGNATUREBYTES],
-        siglen: &mut usize,
         message: &[u8],
         sk: &[u8; SECRETKEYBYTES],
     ) -> c_int {
         unsafe {
             PQCLEAN_DILITHIUM5_CLEAN_crypto_sign_signature(
-                sig as *mut u8,
-                siglen as *mut usize,
+                sig as *mut _,
                 message.as_ptr(),
                 message.len(),
                 sk as *const _,
@@ -68,14 +64,13 @@ pub mod clean {
     }
 
     pub unsafe fn crypto_sign_verify(
-        sig: &[u8],
+        sig: &[u8; SIGNATUREBYTES],
         message: &[u8],
         pk: &[u8; PUBLICKEYBYTES],
     ) -> c_int {
         unsafe {
             PQCLEAN_DILITHIUM5_CLEAN_crypto_sign_verify(
-                sig.as_ptr(),
-                sig.len(),
+                sig as *const _,
                 message.as_ptr(),
                 message.len(),
                 pk as *const _,
@@ -99,11 +94,10 @@ pub mod clean {
             assert_eq!(res, 0);
 
             let mut sig = [0u8; SIGNATUREBYTES];
-            let mut len: usize = 0;
-            let res = unsafe { crypto_sign_signature(&mut sig, &mut len, &msg[..], &seckey) };
+            let res = unsafe { crypto_sign_signature(&mut sig, &msg[..], &seckey) };
             assert_eq!(res, 0);
 
-            let res = unsafe { crypto_sign_verify(&sig[..len], &msg[..], &pubkey) };
+            let res = unsafe { crypto_sign_verify(&sig, &msg[..], &pubkey) };
             assert_eq!(res, 0, "Invalid signature crated!");
         }
     }
@@ -126,16 +120,14 @@ pub mod avx2 {
         ) -> c_int;
 
         fn PQCLEAN_DILITHIUM5_AVX2_crypto_sign_signature(
-            sig: *mut u8,
-            siglen: *mut size_t,
+            sig: *mut [u8; SIGNATUREBYTES],
             m: *const u8,
             mlen: size_t,
             sk: *const [u8; SECRETKEYBYTES],
         ) -> c_int;
 
         fn PQCLEAN_DILITHIUM5_AVX2_crypto_sign_verify(
-            sig: *const u8,
-            siglen: size_t,
+            sig: *const [u8; SIGNATUREBYTES],
             m: *const u8,
             mlen: size_t,
             pk: *const [u8; PUBLICKEYBYTES],
@@ -158,14 +150,12 @@ pub mod avx2 {
 
     pub unsafe fn crypto_sign_signature(
         sig: &mut [u8; SIGNATUREBYTES],
-        siglen: &mut usize,
         message: &[u8],
         sk: &[u8; SECRETKEYBYTES],
     ) -> c_int {
         unsafe {
             PQCLEAN_DILITHIUM5_AVX2_crypto_sign_signature(
-                sig as *mut u8,
-                siglen as *mut usize,
+                sig as *mut _,
                 message.as_ptr(),
                 message.len(),
                 sk as *const _,
@@ -174,14 +164,13 @@ pub mod avx2 {
     }
 
     pub unsafe fn crypto_sign_verify(
-        sig: &[u8],
+        sig: &[u8; SIGNATUREBYTES],
         message: &[u8],
         pk: &[u8; PUBLICKEYBYTES],
     ) -> c_int {
         unsafe {
             PQCLEAN_DILITHIUM5_AVX2_crypto_sign_verify(
-                sig.as_ptr(),
-                sig.len(),
+                sig as *const _,
                 message.as_ptr(),
                 message.len(),
                 pk as *const _,
@@ -205,11 +194,10 @@ pub mod avx2 {
             assert_eq!(res, 0);
 
             let mut sig = [0u8; SIGNATUREBYTES];
-            let mut len: usize = 0;
-            let res = unsafe { crypto_sign_signature(&mut sig, &mut len, &msg[..], &seckey) };
+            let res = unsafe { crypto_sign_signature(&mut sig, &msg[..], &seckey) };
             assert_eq!(res, 0);
 
-            let res = unsafe { crypto_sign_verify(&sig[..len], &msg[..], &pubkey) };
+            let res = unsafe { crypto_sign_verify(&sig, &msg[..], &pubkey) };
             assert_eq!(res, 0, "Invalid signature crated!");
         }
     }
@@ -232,16 +220,14 @@ pub mod aarch64 {
         ) -> c_int;
 
         fn PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_signature(
-            sig: *mut u8,
-            siglen: *mut size_t,
+            sig: *mut [u8; SIGNATUREBYTES],
             m: *const u8,
             mlen: size_t,
             sk: *const [u8; SECRETKEYBYTES],
         ) -> c_int;
 
         fn PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_verify(
-            sig: *const u8,
-            siglen: size_t,
+            sig: *const [u8; SIGNATUREBYTES],
             m: *const u8,
             mlen: size_t,
             pk: *const [u8; PUBLICKEYBYTES],
@@ -264,14 +250,12 @@ pub mod aarch64 {
 
     pub unsafe fn crypto_sign_signature(
         sig: &mut [u8; SIGNATUREBYTES],
-        siglen: &mut usize,
         message: &[u8],
         sk: &[u8; SECRETKEYBYTES],
     ) -> c_int {
         unsafe {
             PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_signature(
-                sig as *mut u8,
-                siglen as *mut usize,
+                sig as *mut _,
                 message.as_ptr(),
                 message.len(),
                 sk as *const _,
@@ -280,14 +264,13 @@ pub mod aarch64 {
     }
 
     pub unsafe fn crypto_sign_verify(
-        sig: &[u8],
+        sig: &[u8; SIGNATUREBYTES],
         message: &[u8],
         pk: &[u8; PUBLICKEYBYTES],
     ) -> c_int {
         unsafe {
             PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_verify(
-                sig.as_ptr(),
-                sig.len(),
+                sig as *const _,
                 message.as_ptr(),
                 message.len(),
                 pk as *const _,
@@ -311,11 +294,10 @@ pub mod aarch64 {
             assert_eq!(res, 0);
 
             let mut sig = [0u8; SIGNATUREBYTES];
-            let mut len: usize = 0;
-            let res = unsafe { crypto_sign_signature(&mut sig, &mut len, &msg[..], &seckey) };
+            let res = unsafe { crypto_sign_signature(&mut sig, &msg[..], &seckey) };
             assert_eq!(res, 0);
 
-            let res = unsafe { crypto_sign_verify(&sig[..len], &msg[..], &pubkey) };
+            let res = unsafe { crypto_sign_verify(&sig, &msg[..], &pubkey) };
             assert_eq!(res, 0, "Invalid signature crated!");
         }
     }


### PR DESCRIPTION
I noticed that `crypto_sign_signature` always sets the `siglen` argument to the constant `SIGNATUREBYTES` (`DILITHIUM_NAMESPACE(CRYPTO_BYTES)` in C), and the only use of `siglen` in `crypto_sign_verify` was to check that it equaled this constant. Since this length is already captured by the type `Signature`, there is no need to keep it at runtime. So I removed it from the C API and from Rust.